### PR TITLE
add champion/stakeholders table

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,25 @@ Work needed includes:
 - Collect and document projects and products providing diagnostics for Node with brief description of their technical architecture and sponsoring organizations.
 - Identify opportunities and gaps, then propose and implement solutions.
 
+### Current Initiatives
+
+| Initiative           | Champion                                         | Stakeholders                            | Links                                            |
+|----------------------|--------------------------------------------------|-----------------------------------------|--------------------------------------------------|
+| Diagnostic Channel   | [@qard](https://github.com/qard)                 |                                         | https://github.com/nodejs/diagnostics/issues/180 |
+| Async Hooks          | [@ofrobots](https://github.com/ofrobots)         |                                         | https://github.com/nodejs/diagnostics/issues/124 |
+| Async Context        | [@mike-kaufman](https://github.com/mike-kaufman) | [@kjin](https://github.com/kjin)        | https://github.com/nodejs/diagnostics/issues/107 |
+
+#### Need volunteers for
+
+| Initiative            | Champion      | Links                                            |
+|-----------------------|---------------|--------------------------------------------------|
+| CPU Profiling         |               | https://github.com/nodejs/diagnostics/issues/148 |
+| Support tiers         |               | https://github.com/nodejs/diagnostics/issues/157 |
+| Trace Events          |               | https://github.com/nodejs/diagnostics/issues/84  |
+| Performance Profiles  |               | https://github.com/nodejs/diagnostics/issues/161 |
+| Time-travel debugging |               | https://github.com/nodejs/diagnostics/issues/164 |
+| Platform neutrality   |               |                                                  |
+
 ### Logistics
 - Monthly Meetings
 - Biannual F2F


### PR DESCRIPTION
This PR adds the champions table to the README as mentioned in #185.

I'm not aware of who is championing some of the issues, so for now they are listed under "need volunteers". Please let me know if there are any additions I should make (also, the branch is editable by maintainers).