### PR TITLE
resync team with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Work needed includes:
 - [@piscisaureus](https://github.com/piscisaureus) - Bert Belder
 - [@pmuellr](https://github.com/pmuellr) - Patrick Mueller
 - [@Qard](https://github.com/Qard) - Stephen Belanger
-- [@rmg](https://github.com/rmg) - Ryan Graham
 - [@sam-github](https://github.com/sam-github) - Sam Roberts
 - [@thekemkid](https://github.com/thekemkid) - Glen Keane
 - [@thlorenz](https://github.com/thlorenz) - Thorsten Lorenz


### PR DESCRIPTION
@rmg removed themselves from the @nodejs/diagnostics team on June 20. Resynch the list of people in the README against the GitHub team.

(The team currently has 31 people. If there are really that many people active in the Diagnostics WG, then awesome! But if that contains a lot of folks who aren't active anymore, it might be a good idea to do some pruning. Or not if extra folks don't adversely affect anything. In some groups, that can be a problem when doing things like taking votes or abiding by rules about quorum.)