### PR TITLE
Add graphql-subscriptions to list of modules breaking async continuity

### DIFF
--- a/tracing/AsyncHooks/problematic-modules.md
+++ b/tracing/AsyncHooks/problematic-modules.md
@@ -17,3 +17,4 @@ Module | Embedder API | Note
 [bluebird](https://github.com/petkaantonov/bluebird) | [PR#1472](https://github.com/petkaantonov/bluebird/pull/1472) |
 [generic-pool](https://github.com/coopernurse/node-pool) | No | Used by a lot of database modules like for instance "pg"
 [mongoose](https://github.com/Automattic/mongoose/) | [#5929](https://github.com/Automattic/mongoose/issues/5929) | Most popular MongoDB ORM/ODM that implements its own user-land queueing.
+[graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions/blob/26ed503566ecfab086e7530f0daf12b60ee3049c/src/pubsub-async-iterator.ts) | No | De-facto standard for working with GraphQL subscriptions. Custom queueing via an async iterator written in TypeScript and compiled down to ES5.


### PR DESCRIPTION
Not sure if this list is still maintained or not, but if it is, the `graphql-subscriptions` should be on it. It has a [custom queueing mechanism](https://github.com/apollographql/graphql-subscriptions/blob/26ed503566ecfab086e7530f0daf12b60ee3049c/src/pubsub-async-iterator.ts). 

It works roughly like this: GraphQL subscriptions use an instance of the async iterator. The subscription engine waits for new events by calling `next()` on it, which internally calls `pullValue()`, which in turn creates a promise and puts that promise's `resolve` function into an internal queue called pullQueue ([here](https://github.com/apollographql/graphql-subscriptions/blob/26ed503566ecfab086e7530f0daf12b60ee3049c/src/pubsub-async-iterator.ts#L94)).

When a new event is published via `pushValue`, the resolve function is pulled out of that queue and called with the event that is to be published. This is where async continuity is lost, in particular, the execution of the `then` of that promise is not connected to the async context of the call to `pushValue`.

My guess is that the reason for this is that the promise has already been created earlier, outside of that context. The different approaches to promises discussed in <https://github.com/othiym23/node-continuation-local-storage/issues/64> might be relevant here. As a matter of fact, I stumbled upon this while using https://github.com/jeff-lewis/cls-hooked, which relies on `async_hooks` internally.

As a user of `async_hooks` I would expect that everything that is triggered by publishing the event (that is, calling `pushValue`) happens in that context. The module `graphql-subscriptions` breaks that expectation.