### PR TITLE
docs(live-debugging): add README

### DIFF
--- a/documentation/live_debugging/README.md
+++ b/documentation/live_debugging/README.md
@@ -1,0 +1,21 @@
+# Live Debugging
+
+In this document you can learn about how to live debug a Node.js process.
+
+## My application doesn’t behave as expected
+
+### Symptoms
+
+The user may observe that the application doesn’t provide the expected output
+for certain inputs, for example, an HTTP server returns a JSON response where
+certain fields are empty. Various things can go wrong in the process but in this
+use case, we are mainly focused on the application logic and its correctness.
+
+### Debugging
+
+In this use case, the user would like to understand the code path that our
+application executes for a certain trigger like an incoming HTTP request. They
+may also want to step through the code and control the execution as well as
+inspect what values variables hold in memory.
+
+- [Using Inspector](./step1/using_inspector.md)

--- a/documentation/live_debugging/step1/using_inspector.md
+++ b/documentation/live_debugging/step1/using_inspector.md
@@ -1,1 +1,16 @@
+# Using Inspector
+
+In a local environment, we usually speak about live debugging where we attach a
+debugger to our application and we add breakpoints to suspend the program
+execution. Then we step through the code paths and inspect our heap over the
+different steps. Using the live debugger in production is usually not an option
+as we have limited access to the machine and we cannot interrupt the execution
+of the application as it handles a business-critical workload.
+
+## How To
+
 //TODO
+
+## Useful Links
+
+- https://nodejs.org/en/docs/guides/debugging-getting-started_


### PR DESCRIPTION
I started to move the [user journey's doc](https://docs.google.com/document/d/1fAvQyelASBK5qkZiF4CP9LXqWxfAAhhSh37iBNKb-GQ/edit#heading=h.c521enci12m1) content to our new documentation structure.
