### PR TITLE
docs(documentation): improve process crash

### DIFF
--- a/documentation/abnormal_termination/README.md
+++ b/documentation/abnormal_termination/README.md
@@ -53,11 +53,13 @@ You can find the most common scenarios for native crashes here:
 1. Native module crashes due bug
 2. Native module crashes due memory leak (native memory leak)
 3. Bugs in Node.js runtime and dependencies, for example:
+   - Accessing garbage collected data
+   - Accessing NULL pointer
+   - Attempting to process invalid file descriptors
+   - Use native API compiled on linux using glibc on Alpine which uses Musl
    - V8 checks, when input data checking to v8 APIs is missing can lead to a crash
-   - Access garbage collected data
    - Call v8 APIs without HandleScope
    - Call v8 APIs from wrong Thread
-   - Use native API compiled on linux using glibc on Alpine which uses Musl
 
 Check out the following guides to root cause the issue:
 

--- a/documentation/abnormal_termination/README.md
+++ b/documentation/abnormal_termination/README.md
@@ -52,8 +52,12 @@ You can find the most common scenarios for native crashes here:
 
 1. Native module crashes due bug
 2. Native module crashes due memory leak (native memory leak)
-3. Bugs in Node.js runtime and dependencies
-  - For example: V8 checks, when input checking is missing can lead to crash
+3. Bugs in Node.js runtime and dependencies, for example:
+   - V8 checks, when input data checking to v8 APIs is missing can lead to a crash
+   - Access garbage collected data
+   - Call v8 APIs without HandleScope
+   - Call v8 APIs from wrong Thread
+   - Use native API compiled on linux using glibc on Alpine which uses Musl
 
 Check out the following guides to root cause the issue:
 
@@ -78,9 +82,9 @@ information to root cause the issue, for example:
 
 1. Third party library uses general error messages
 2. Stack trace frame limit cuts important frames
-3. Error is tampered by error handling pipeline
-  1. Error is rethrown (tampered stack trace)
-  2. Error is wrapped (tampered message)
+3. Error is tampered by error handling pipeline, for example:
+   - Error is rethrown (tampered stack trace)
+   - Error is wrapped (tampered message)
 
 Check out the following guides to root cause the issue:
 

--- a/documentation/abnormal_termination/README.md
+++ b/documentation/abnormal_termination/README.md
@@ -7,7 +7,11 @@ In this document you can learn about how to debug process crashes or unexpected 
   - [Introduction](#introduction)
   - [Common Symptoms](#common-symptoms)
     - [Process silently exits](#process-silently-exits)
-  - [Debugging](#debugging)
+    - [Process exits with Native Stack Trace](#process-exits-with-native-stack-trace)
+    - [Process exits with JavaScript Stack Trace](#process-exits-with-javascript-stack-trace)
+      - [Sufficient Message and Stack Trace](#sufficient-message-and-stack-trace)
+      - [Insufficient Message and Stack Trace](#insufficient-message-and-stack-trace)
+  - [Advanced debugging](#advanced-debugging)
 
 ## Introduction
 
@@ -29,7 +33,7 @@ $ node index.js
 $ # process exited
 ```
 
-There are three reasons for a process to exit silently: 
+There are three reasons for a process to exit silently:
 
   1. The process was finished by using `process.exit()`
   2. The process received a termination signal
@@ -39,11 +43,49 @@ To find out if the process exited because of a `process.exit()` call, follow [Us
 
 ### Process exits with Native Stack Trace
 
-TBD
+Some Node.js application uses native modules to re-use existing components or
+performance optimize specific areas. A common example for native modules are
+database drivers. In the case our native module has an issue it can crash the
+Node.js application which will generate a native stack trace.
 
-### Process exits with unmeaningful Stack Trace
+You can find the most common scenarios for native crashes here:
 
-TBD
+1. Native module crashes due bug
+2. Native module crashes due memory leak (native memory leak)
+3. Bugs in Node.js runtime and dependencies
+  - For example: V8 checks, when input checking is missing can lead to crash
+
+Check out the following guides to root cause the issue:
+
+- [Using Diagnostic Report](step2/using_diagnostic_report.md)
+- [Using Valgrind](step4/using_valgrind.md)
+
+### Process exits with JavaScript Stack Trace
+
+In this scenario our application exists with a JavaScript stack trace.
+We differentiate two bug use-cases here; when the error message and stack trace
+provides enough information to root cause the issue and when it doesn't.
+
+#### Sufficient Message and Stack Trace
+
+In this case the stack trace and error message has enough information to root
+cause the issue. This use case doesn't require to use diagnostics tools.
+
+#### Insufficient Message and Stack Trace
+
+In this case the error message or the stack trace doesn't contain enough
+information to root cause the issue, for example:
+
+1. Third party library uses general error messages
+2. Stack trace frame limit cuts important frames
+3. Error is tampered by error handling pipeline
+  1. Error is rethrown (tampered stack trace)
+  2. Error is wrapped (tampered message)
+
+Check out the following guides to root cause the issue:
+
+- [Using Diagnostic Report](step2/using_diagnostic_report.md)
+- [Using Core Dumps With lldb](step3/using_lldb.md)
 
 ## Advanced debugging
 

--- a/documentation/abnormal_termination/step2/using_diagnostic_report.md
+++ b/documentation/abnormal_termination/step2/using_diagnostic_report.md
@@ -8,7 +8,15 @@ configuration and component version issues with in your process.
 
 ## How To
 
-//TODO
+//TODO, raw notes from deep dive:
+
+1. Open the generated report (either from file or from console)
+2. Take a look to allocation section in the report
+3. Look for the old_space
+    - used is high
+    - available is very low
+4. Look javascriptStack to see the victim of the memory leak which can be the allocation pattern and source to find what causes it (JavaScript stack trace won’t always point to the right frame, can be confusing)
+5. -> see memory related user journeys to identify exact cause
 
 ## Useful Links
 

--- a/documentation/abnormal_termination/step3/using_lldb.md
+++ b/documentation/abnormal_termination/step3/using_lldb.md
@@ -1,1 +1,9 @@
-//TODO
+# Using llnode (lldb)
+
+//TODO, raw notes from deep dive:
+
+1. Grab Core Dump and load it to llnode
+2. Run v8 findjsobjects
+   - This gives a list of object types with size + count
+   - If a class Foo, you can use findrefs
+3. -> if you can’t find the cause, see memory related user journeys to identify exact cause

--- a/documentation/abnormal_termination/step4/using_valgrind.md
+++ b/documentation/abnormal_termination/step4/using_valgrind.md
@@ -1,0 +1,8 @@
+# Using Valgrind
+
+A Node.js process may run out of memory due to excessive consumption of native
+memory which can lead to a native crash. Valgrind is a diagnostics tool on Linux
+machines to help investigating native memory leaks.
+
+Check out the [Investigating Memory Leaks with valgrind](https://github.com/nodejs/node/blob/master/doc/guides/investigating_native_memory_leak.md) guide to learn more about how to use
+Valgrind.


### PR DESCRIPTION
I incorporated the docs from the first deep dive (process crash) to our guides:
https://docs.google.com/document/d/1gd_4hlDK-DacbyTnFcqLPdCjM1Q1z02MdkFaUddPLCE/edit?ts=5de804b8#