### PR TITLE
chore(github): add stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
+        stale-issue-label: 'stale'
+        exempt-issue-label: 'never stale'
+        days-before-stale: 90
+        days-before-close: 14


### PR DESCRIPTION
Add Stale actions to help keep the issue tracker cleaner. Issues
inactive for 90 days will be marked as `stale`, and issues marked as
stale for 14 days will be automatically closed. The label `never stale`
can be used to skip certain issues.