### PR TITLE
Emeritus Member username updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See the [foundation calendar](https://nodejs.org/calendar) for meeting times.
 - [@piscisaureus](https://github.com/piscisaureus) - Bert Belder
 - [@pmuellr](https://github.com/pmuellr) - Patrick Mueller
 - [@rmg](https://github.com/rmg) - Ryan Graham
-- [@thekemkid](https://github.com/thekemkid) - Glen Keane
+- [@GlenTiki](https://github.com/GlenTiki) - Glen Keane
 - [@thlorenz](https://github.com/thlorenz) - Thorsten Lorenz
 - [@trevnorris](https://github.com/trevnorris) - Trevor Norris
 - [@danielkhan](https://github.com/danielkhan) - Daniel Khan


### PR DESCRIPTION
Glen Keane seems to have renamed their Github username from 'thekemkid' to 'GlenTiki'.
Github seems to be redirecting (301) the user's repo links but not the profile link.