### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goal of this WG is to ensure Node provides a set of comprehensive, documente
 
 Work is divided into several domains:
 - [Tracing](./tracing)
-- [Profiling](./profiling)
+- [Profiling](./documentation/poor-performance)
 - [Heap and Memory Analysis](./heap-memory)
 - [Step Debugging](./debugging)
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 
 The goal of this WG is to ensure Node provides a set of comprehensive, documented, extensible diagnostic protocols, formats, and APIs to enable tool vendors to provide reliable diagnostic tools for Node.
 
-Work is divided into several domains:
-- [Tracing](./tracing)
-- [Profiling](./documentation/poor-performance)
-- [Heap and Memory Analysis](./heap-memory)
-- [Step Debugging](./debugging)
-
-Background, reference documentation, samples, and discussion for each domain is contained within its folder.
-
 Work needed includes:
 - Collect, understand, and document existing diagnostic capabilities and entry-points throughout Node, V8, and other components.
 - Collect and document projects and products providing diagnostics for Node with brief description of their technical architecture and sponsoring organizations.


### PR DESCRIPTION
Hi :wave: :smiley:

* the root folder for profiling has been removed: https://github.com/nodejs/diagnostics/commit/ea04ac4b16bb90c4b8b36e04232e4f2c90b023a0
* the profiling documentation has been renamed to _poor performance_: https://github.com/nodejs/diagnostics/commit/d883b2ea6d07c3e6524584db6fef45b2deffccd3

then the `profiling` link in the main README is broken... I'm wondering if this documentation page is the logical replacement :man_shrugging: .
Thanks for your work :bow: 
Have a nice day