### PR TITLE
chore: fix exempt issue labels for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
         stale-issue-label: 'stale'
-        exempt-issue-label: 'never stale'
+        exempt-issue-labels: 'never stale'
         days-before-stale: 90
         days-before-close: 14


### PR DESCRIPTION
Version 2 of actions/stale changed the option for
exempt issue labels from the singular 
`exempt-issue-label` 
to the plural 
`exempt-issue-labels`.

Refs: https://github.com/actions/stale/pull/19
Refs: https://github.com/nodejs/build/pull/2704